### PR TITLE
Adapt documents scrapers to only update RawBillDocuments and RawMotionDocuments.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,8 @@ scrape-motions:
 scrape-leyes:
 	uv run -m backend --scrape --skip-processing --only-leyes
 
+scrape-documents:
+	uv run -m backend --scrape --skip-processing --scrape-documents
+
 process:
 	uv run -m backend

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -41,7 +41,7 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Run only non-bill/non-motion entities (congresistas, bancadas, organizations)",
     )
-    parser.add_argument(
+    target_group.add_argument(
         "--scrape-documents",
         action="store_true",
         help="Scrape pending bill/motion documents",
@@ -63,23 +63,33 @@ def main(argv: list[str] | None = None) -> None:
     run_motions = True
     run_leyes = True
     run_others = True
+    run_documents = True
 
     if args.only_bills:
         run_motions = False
         run_others = False
         run_leyes = False
+        run_documents = False
     elif args.only_motions:
         run_bills = False
         run_others = False
         run_leyes = False
+        run_documents = False
     elif args.only_leyes:
         run_motions = False
         run_bills = False
         run_others = False
+        run_documents = False
     elif args.only_others:
         run_bills = False
         run_motions = False
         run_leyes = False
+        run_documents = False
+    elif args.scrape_documents:
+        run_bills = False
+        run_motions = False
+        run_leyes = False
+        run_others = False
 
     if args.scrape:
         orchestrator.run_scrapers(
@@ -88,7 +98,7 @@ def main(argv: list[str] | None = None) -> None:
             scrape_leyes=run_leyes,
             scrape_others=run_others,
             only_current=args.only_current,
-            scrape_documents=args.scrape_documents,
+            scrape_documents=run_documents,
         )
 
     if not args.skip_processing:

--- a/backend/database/orchestrator.py
+++ b/backend/database/orchestrator.py
@@ -533,7 +533,10 @@ class OpenPeruOrchestrator:
         bill_ids = bill_docs.get_bills_pending_documents()
         for bill_id in tqdm(bill_ids, desc="Bill documents"):
             bill_docs.get_bill_documents(
-                bill_id=bill_id, update=False, download_local=True, upload_s3=False
+                bill_id=bill_id,
+                update=False,
+                download_local=False,
+                upload_s3=False,
             )
             count += len(bill_docs.documents)
             bill_docs.load_raw_documents()
@@ -546,7 +549,10 @@ class OpenPeruOrchestrator:
         motion_ids = motion_docs.get_motions_pending_documents()
         for motion_id in tqdm(motion_ids, desc="Motion documents"):
             motion_docs.get_motion_documents(
-                motion_id=motion_id, update=False, download_local=True, upload_s3=False
+                motion_id=motion_id,
+                update=False,
+                download_local=False,
+                upload_s3=False,
             )
             count += len(motion_docs.documents)
             motion_docs.load_raw_documents()

--- a/backend/database/orchestrator.py
+++ b/backend/database/orchestrator.py
@@ -339,7 +339,7 @@ class OpenPeruOrchestrator:
                 )
                 self._load_scraper_results("motions.py")
 
-        if scrape_documents and (scrape_bills or scrape_motions):
+        if scrape_documents:
             with log_manager.stage("scraper", "documents") as stage_logger:
                 console.info("Starting document scraper")
                 stage_logger.info("Starting document scraper")

--- a/backend/scrapers/bills_documents.py
+++ b/backend/scrapers/bills_documents.py
@@ -141,8 +141,8 @@ class RawBillDocumentScraper:
 
                 new_doc = RawBillDocument(
                     bill_id=bill_id,
-                    step_id=step_id,
-                    file_id=file_id,
+                    step_id=str(step_id),
+                    file_id=str(file_id),
                     step_date=datetime.strptime(step_date, "%Y-%m-%dT%H:%M:%S.%f%z"),
                     url=url,
                     s3_key=s3_key,

--- a/backend/scrapers/bills_documents.py
+++ b/backend/scrapers/bills_documents.py
@@ -6,14 +6,15 @@ from datetime import datetime
 from pathlib import Path
 
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy import create_engine, select
+from sqlalchemy import create_engine, select, Integer, cast, exists
 from sqlalchemy.exc import SQLAlchemyError
 
 from backend.config import settings, directories
-from backend.scrapers.utils import render_pdf, get_url
-from backend.database.raw_models import RawBillDocument, RawBill, RawBillPage
+from backend.scrapers.utils import get_url
+from backend.database.raw_models import RawBillDocument, RawBill
+from backend.database.models import BillStep
 
-BASE_URL = "https://wb2server.congreso.gob.pe/spley-portal-service/"
+BASE_URL = "https://api.congreso.gob.pe/spley-portal-service/"
 DB_PATH = settings.DB_URL
 
 
@@ -28,17 +29,40 @@ class RawBillDocumentScraper:
         self.Session = sessionmaker(bind=self.engine)
 
         self.documents: list[RawBillDocument] = []
-        self.pages: list[RawBillPage] = []
 
     def get_bills_pending_documents(self) -> list[str]:
+        """
+        Return bill IDs that have at least one step without a scraped document.
+
+        A bill is considered pending when it has a record in `bill_steps` for a
+        given step, but there is no matching record in `raw_bill_documents` for the
+        same `bill_id` and `step_id`.
+
+        Returns:
+            list[str]: Distinct bill IDs with one or more missing raw documents.
+        """
+
         with self.Session() as session:
             stmt = (
                 select(RawBill.id)
-                .outerjoin(RawBillDocument, RawBill.id == RawBillDocument.bill_id)
-                .where(RawBillDocument.bill_id.is_(None))
+                .distinct()
+                .where(
+                    exists(
+                        select(1).where(
+                            BillStep.bill_id == RawBill.id,
+                            ~exists(
+                                select(1).where(
+                                    RawBillDocument.bill_id == BillStep.bill_id,
+                                    cast(RawBillDocument.step_id, Integer)
+                                    == BillStep.step_id,
+                                )
+                            ),
+                        )
+                    )
+                )
             )
 
-            return session.scalars(stmt).all()
+            return list(session.scalars(stmt).all())
 
     def filter_steps(self, extracted_steps: list[dict], bill_id: str):
         """
@@ -62,10 +86,11 @@ class RawBillDocumentScraper:
     def get_bill_documents(
         self,
         bill_id: str,
+        *,
         update: bool = False,
         download_local: bool = False,
         upload_s3: bool = False,
-    ) -> tuple[list[RawBillDocument], list[RawBillPage]] | None:
+    ) -> None:
         """
         Extract the urls from a RawBill's files and extract the text from each of its pages
         """
@@ -90,7 +115,7 @@ class RawBillDocumentScraper:
 
         logger.info(f"Extracting files from {len(steps)} steps of bill {bill_id}")
 
-        for ix, step in enumerate(steps):
+        for _, step in enumerate(steps):
             files = step.get("archivos")
             step_date = step.get("fecha")
 
@@ -103,9 +128,6 @@ class RawBillDocumentScraper:
 
                 b64_id = base64.b64encode(str(file_id).encode()).decode()
                 url = f"{BASE_URL}/archivo/{b64_id}/pdf"
-                logger.info(f"Extracting document {ix + 1}/{len(steps)} at url: {url}")
-                pages_text = render_pdf(url)
-                logger.success(f"Successfully extracted text from {url}")
 
                 file_name = self._build_filename(bill_id, step_id, file_id)
                 dest_path = directories.BILL_DOCUMENTS / file_name
@@ -129,18 +151,6 @@ class RawBillDocumentScraper:
                     processed=False,
                     last_update=True,
                 )
-
-                for page_num, text in pages_text.items():
-                    self.pages.append(
-                        RawBillPage(
-                            bill_id=bill_id,
-                            step_id=step_id,
-                            file_id=file_id,
-                            page_num=page_num,
-                            text=text,
-                            ocr_model="Tesseract",  # TODO: Add models to the pipeline
-                        )
-                    )
 
                 self.documents.append(new_doc)
 
@@ -168,36 +178,10 @@ class RawBillDocumentScraper:
                 session.rollback()
                 return False
 
-    def add_pages_to_db(self) -> bool:
-        """
-        Add the pages to the database.
-        Returns True on success, False on failure.
-        """
-
-        assert self.pages, "Pages must be scraped before it can be saved"
-
-        with self.Session() as session:
-            try:
-                session.add_all(self.pages)
-                session.commit()
-                logger.success(
-                    f"Added {len(self.pages)} documents to Raw Bill Pages table"
-                )
-                return True
-
-            except SQLAlchemyError as e:
-                logger.error(
-                    f"Failed to add pages from bill {self.pages[0].bill_id}: {e}"
-                )
-                session.rollback()
-                return False
-
     def load_raw_documents(self):
         if self.documents:
             self.add_documents_to_db()
-            self.add_pages_to_db()
             self.documents = []
-            self.pages = []
         else:
             return None
 

--- a/backend/scrapers/bills_documents.py
+++ b/backend/scrapers/bills_documents.py
@@ -146,7 +146,7 @@ class RawBillDocumentScraper:
                     step_date=datetime.strptime(step_date, "%Y-%m-%dT%H:%M:%S.%f%z"),
                     url=url,
                     s3_key=s3_key,
-                    local_path=dest_path,
+                    local_path=str(dest_path) if dest_path is not None else None,
                     timestamp=datetime.now(),
                     processed=False,
                     last_update=True,

--- a/backend/scrapers/motions_documents.py
+++ b/backend/scrapers/motions_documents.py
@@ -146,7 +146,7 @@ class RawMotionDocumentScraper:
                     step_date=datetime.strptime(step_date, "%Y-%m-%dT%H:%M:%S.%f%z"),
                     url=url,
                     s3_key=s3_key,
-                    local_path=dest_path,
+                    local_path=str(dest_path) if dest_path is not None else None,
                     timestamp=datetime.now(),
                     processed=False,
                     last_update=True,

--- a/backend/scrapers/motions_documents.py
+++ b/backend/scrapers/motions_documents.py
@@ -141,8 +141,8 @@ class RawMotionDocumentScraper:
 
                 new_doc = RawMotionDocument(
                     motion_id=motion_id,
-                    step_id=step_id,
-                    file_id=file_id,
+                    step_id=str(step_id),
+                    file_id=str(file_id),
                     step_date=datetime.strptime(step_date, "%Y-%m-%dT%H:%M:%S.%f%z"),
                     url=url,
                     s3_key=s3_key,

--- a/backend/scrapers/motions_documents.py
+++ b/backend/scrapers/motions_documents.py
@@ -6,12 +6,13 @@ from datetime import datetime
 from pathlib import Path
 
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy import create_engine, select
+from sqlalchemy import create_engine, select, Integer, cast, exists
 from sqlalchemy.exc import SQLAlchemyError
 
 from backend.config import settings, directories
-from backend.scrapers.utils import render_pdf, get_url
-from backend.database.raw_models import RawMotionDocument, RawMotion, RawMotionPage
+from backend.scrapers.utils import get_url
+from backend.database.raw_models import RawMotionDocument, RawMotion
+from backend.database.models import MotionStep
 
 BASE_URL = "https://api.congreso.gob.pe/smociones-portal-service"
 DB_PATH = settings.DB_URL
@@ -28,19 +29,39 @@ class RawMotionDocumentScraper:
         self.Session = sessionmaker(bind=self.engine)
 
         self.documents: list[RawMotionDocument] = []
-        self.pages: list[RawMotionPage] = []
 
     def get_motions_pending_documents(self) -> list[str]:
+        """
+        Return motion IDs that have at least one step without a scraped document.
+
+        A motion is considered pending when it has a record in `motion_steps` for a
+        given step, but there is no matching record in `raw_motion_documents` for the
+        same `motion_id` and `step_id`.
+
+        Returns:
+            list[str]: Distinct motion IDs with one or more missing raw documents.
+        """
         with self.Session() as session:
             stmt = (
                 select(RawMotion.id)
-                .outerjoin(
-                    RawMotionDocument, RawMotion.id == RawMotionDocument.motion_id
+                .distinct()
+                .where(
+                    exists(
+                        select(1).where(
+                            MotionStep.motion_id == RawMotion.id,
+                            ~exists(
+                                select(1).where(
+                                    RawMotionDocument.motion_id == MotionStep.motion_id,
+                                    cast(RawMotionDocument.step_id, Integer)
+                                    == MotionStep.step_id,
+                                )
+                            ),
+                        )
+                    )
                 )
-                .where(RawMotionDocument.motion_id.is_(None))
             )
 
-            return session.scalars(stmt).all()
+            return list(session.scalars(stmt).all())
 
     def filter_steps(self, extracted_steps: list[dict], motion_id: str):
         """
@@ -62,10 +83,11 @@ class RawMotionDocumentScraper:
     def get_motion_documents(
         self,
         motion_id: str,
+        *,
         update: bool = False,
         download_local: bool = False,
         upload_s3: bool = False,
-    ) -> tuple[list[RawMotionDocument], list[RawMotionPage]] | None:
+    ) -> None:
         """
         Extract the documents from a RawMotion's files and extract the text from each of its pages
         """
@@ -93,7 +115,7 @@ class RawMotionDocumentScraper:
 
         logger.info(f"Extracting files from {len(steps)} steps of motion {motion_id}")
 
-        for ix, step in enumerate(steps):
+        for _, step in enumerate(steps):
             files = step.get("adjuntos")
             step_date = step.get("fecSeguimiento")
 
@@ -106,9 +128,6 @@ class RawMotionDocumentScraper:
 
                 b64_id = base64.b64encode(str(file_id).encode()).decode()
                 url = f"{BASE_URL}/seguimiento-adjunto/{b64_id}/pdf"
-                logger.info(f"Extracting document {ix + 1}/{len(steps)} at url: {url}")
-                pages_text = render_pdf(url)
-                logger.success(f"Successfully extracted text from {url}")
 
                 file_name = self._build_filename(motion_id, step_id, file_id)
                 dest_path = directories.MOTION_DOCUMENTS / file_name
@@ -133,17 +152,6 @@ class RawMotionDocumentScraper:
                     last_update=True,
                 )
 
-                for page_num, text in pages_text.items():
-                    self.pages.append(
-                        RawMotionPage(
-                            motion_id=motion_id,
-                            step_id=step_id,
-                            file_id=file_id,
-                            page_num=page_num,
-                            text=text,
-                            ocr_model="Tesseract",  # TODO: Add ocr_model to the pipeline
-                        )
-                    )
                 self.documents.append(new_doc)
 
     def add_documents_to_db(self) -> bool:
@@ -173,36 +181,10 @@ class RawMotionDocumentScraper:
             # Close Session
             session.close()
 
-    def add_pages_to_db(self) -> bool:
-        """
-        Add the pages to the database.
-        Returns True on success, False on failure.
-        """
-
-        assert self.pages, "Documents must be scraped before it can be saved"
-
-        with self.Session() as session:
-            try:
-                session.add_all(self.pages)
-                session.commit()
-                logger.success(
-                    f"Added {len(self.pages)} documents to Raw Motion Documents table"
-                )
-                return True
-
-            except SQLAlchemyError as e:
-                logger.error(
-                    f"Failed to add documents from motion {self.pages[0].motion_id}: {e}"
-                )
-                session.rollback()
-                return False
-
     def load_raw_documents(self):
         if self.documents:
             self.add_documents_to_db()
-            self.add_pages_to_db()
             self.documents = []
-            self.pages = []
         else:
             return None
 

--- a/docker/cron/crontab
+++ b/docker/cron/crontab
@@ -2,8 +2,9 @@ SHELL=/bin/sh
 PATH=/usr/local/bin:/usr/bin:/bin
 CRON_TZ=America/Lima
 
-41 10 * * * /app/docker/cron/run-job.sh scrape-others >> /app/logs/cron.log 2>&1
-15 1 * * * /app/docker/cron/run-job.sh scrape-bills >> /app/logs/cron.log 2>&1
-25 1 * * * /app/docker/cron/run-job.sh scrape-motions >> /app/logs/cron.log 2>&1
-35 9 * * * /app/docker/cron/run-job.sh scrape-leyes >> /app/logs/cron.log 2>&1
-0 7 * * * /app/docker/cron/run-job.sh process >> /app/logs/cron.log 2>&1
+0 0 * * * /app/docker/cron/run-job.sh scrape-others >> /app/logs/cron.log 2>&1
+0 0 * * * /app/docker/cron/run-job.sh scrape-bills >> /app/logs/cron.log 2>&1
+0 0 * * * /app/docker/cron/run-job.sh scrape-motions >> /app/logs/cron.log 2>&1
+0 0 * * * /app/docker/cron/run-job.sh scrape-leyes >> /app/logs/cron.log 2>&1
+0 0 * * * /app/docker/cron/run-job.sh process >> /app/logs/cron.log 2>&1
+0 2 * * * /app/docker/cron/run-job.sh scrape-documents >> /app/logs/cron.log 2>&1

--- a/tests/scrapers/test_bills_documents.py
+++ b/tests/scrapers/test_bills_documents.py
@@ -135,8 +135,8 @@ def test_get_bill_documents_populates_documents(monkeypatch):
     assert len(scraper.documents) == 1
     doc = scraper.documents[0]
     assert doc.bill_id == bill_id
-    assert doc.file_id == 111
-    assert doc.step_id == 10
+    assert doc.file_id == "111"
+    assert doc.step_id == "10"
     assert doc.url == expected_url
     # step_date parsed correctly
     assert isinstance(doc.step_date, datetime)

--- a/tests/scrapers/test_bills_documents.py
+++ b/tests/scrapers/test_bills_documents.py
@@ -89,7 +89,7 @@ def test_get_bill_documents_raises_if_bill_not_found():
         scraper.get_bill_documents(bill_id="2021_999")
 
 
-def test_get_bill_documents_populates_documents_and_calls_render_pdf(monkeypatch):
+def test_get_bill_documents_populates_documents(monkeypatch):
     engine, SessionLocal = _setup_inmemory_db()
 
     scraper = RawBillDocumentScraper()
@@ -126,22 +126,10 @@ def test_get_bill_documents_populates_documents_and_calls_render_pdf(monkeypatch
         )
         session.commit()
 
-    # Patch render_pdf so we don't hit network/PDF
-    calls = []
-
-    def fake_render_pdf(url):
-        calls.append(url)
-        return {1: f"TEXT_FROM_{url}_page_1", 2: f"TEXT_FROM_{url}_page_2"}
-
-    monkeypatch.setattr("backend.scrapers.bills_documents.render_pdf", fake_render_pdf)
-
     scraper.get_bill_documents(bill_id=bill_id)
-    # Should have called render_pdf once
-    assert len(calls) == 1
-    # b64 of "111"
+
     expected_b64 = base64.b64encode(b"111").decode()
     expected_url = f"{BASE_URL}/archivo/{expected_b64}/pdf"
-    assert calls[0] == expected_url
 
     # Scraper should have one RawBillDocument object
     assert len(scraper.documents) == 1
@@ -186,12 +174,6 @@ def test_get_bill_documents_respects_update_flag(monkeypatch):
             )
         )
         session.commit()
-
-    # Patch render_pdf to avoid network
-    monkeypatch.setattr(
-        "backend.scrapers.bills_documents.render_pdf",
-        lambda url: {1: f"TEXT_FROM_{url}_page_1", 2: f"TEXT_FROM_{url}_page_2"},
-    )
 
     # Case 1: update=False and filter_steps returns empty -> no URLs
     def fake_filter_steps(_steps, _bill_id):
@@ -322,10 +304,8 @@ def test_load_raw_documents_calls_add_and_clears(monkeypatch):
         return True
 
     monkeypatch.setattr(scraper, "add_documents_to_db", fake_add)
-    monkeypatch.setattr(scraper, "add_pages_to_db", fake_add)
 
     scraper.load_raw_documents()
 
     assert calls["added"] is True
     assert scraper.documents == []
-    assert scraper.pages == []

--- a/tests/scrapers/test_motions_documents.py
+++ b/tests/scrapers/test_motions_documents.py
@@ -130,8 +130,8 @@ def test_get_motion_documents_populates_urls(monkeypatch):
     expected_url = f"{BASE_URL}/seguimiento-adjunto/{expected_b64}/pdf"
     assert doc.url == expected_url
     assert doc.motion_id == motion_id
-    assert doc.step_id == 10
-    assert doc.file_id == 111
+    assert doc.step_id == "10"
+    assert doc.file_id == "111"
     # Check that step_date was parsed correctly
     assert doc.step_date == datetime.strptime(step_date_str, "%Y-%m-%dT%H:%M:%S.%f%z")
 

--- a/tests/scrapers/test_motions_documents.py
+++ b/tests/scrapers/test_motions_documents.py
@@ -6,7 +6,6 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from backend.database.raw_models import Base as RawBase, RawMotion, RawMotionDocument
-import backend.scrapers.motions_documents as motions_documents
 from backend.scrapers.motions_documents import (
     RawMotionDocumentScraper,
     BASE_URL,
@@ -76,12 +75,11 @@ def test_filter_steps_skips_existing_steps(monkeypatch):
 # --------------------------------------------------------------------------------------
 
 
-def test_get_motion_documents_populates_urls_and_calls_render_pdf(monkeypatch):
+def test_get_motion_documents_populates_urls(monkeypatch):
     """
     get_motion_documents should:
       - fetch the latest RawMotion
       - filter/prioritize steps
-      - call render_pdf for each file
       - populate scraper.documents with RawMotionDocument objects
     """
     engine, SessionLocal = _setup_inmemory_db()
@@ -120,15 +118,6 @@ def test_get_motion_documents_populates_urls_and_calls_render_pdf(monkeypatch):
         )
         session.commit()
 
-    # Patch render_pdf so we don't hit the network
-    captured = {}
-
-    def fake_render_pdf(url):
-        captured["url"] = url
-        return {1: f"TEXT_FROM_{url}_page_1", 2: f"TEXT_FROM_{url}_page_2"}
-
-    monkeypatch.setattr(motions_documents, "render_pdf", fake_render_pdf)
-
     scraper.get_motion_documents(motion_id=motion_id)
 
     # One document should have been created
@@ -140,7 +129,6 @@ def test_get_motion_documents_populates_urls_and_calls_render_pdf(monkeypatch):
     expected_b64 = base64.b64encode(str(111).encode()).decode()
     expected_url = f"{BASE_URL}/seguimiento-adjunto/{expected_b64}/pdf"
     assert doc.url == expected_url
-    assert captured["url"] == expected_url
     assert doc.motion_id == motion_id
     assert doc.step_id == 10
     assert doc.file_id == 111
@@ -234,10 +222,8 @@ def test_load_raw_documents_calls_add_and_resets_urls(monkeypatch):
         return True
 
     monkeypatch.setattr(scraper, "add_documents_to_db", fake_add)
-    monkeypatch.setattr(scraper, "add_pages_to_db", fake_add)
 
     scraper.load_raw_documents()
 
     assert called["called"] is True
     assert scraper.documents == []
-    assert scraper.pages == []


### PR DESCRIPTION
## 1. What does this PR do?

  Update the document scraping pipeline for bills and motions so it records pending document metadata without downloading/rendering PDF pages during scraping.

  This changes the bill and motion document scrapers to:

  - identify pending documents by comparing bill/motion steps against existing raw document records
  - build document URLs using the Congreso API endpoints
  - store step_id, file_id, and local paths in DB-compatible string formats
  - stop rendering PDFs and storing page text during the raw document scrape

  It also adds document scraping as its own CLI/Makefile target and cron job via --scrape-documents, allowing the orchestrator to run document scraping independently from bill or motion scraping.

## 2. How was the functionality tested and verified?
This is a checklist to make sure that the pull request includes complete functionality.

### Code quality
- [x] All new and existing tests pass locally.
- [x] My code added tests using pytest for any new functionality.
- [x] My PR includes documentation updates as relevant (new external commands, updates to options, changes to names, etc.)

### Code review
- [x] If the changes would break previous functionality, I've communicated this in (1)
- [x] If there's anything that the reviewer should know, I've added that as a note on the issue or this pull request.
